### PR TITLE
Update to latest extension API, misc. fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,10 +337,12 @@ dependencies = [
 
 [[package]]
 name = "zed_extension_api"
-version = "0.0.4"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5c51cad4152bb5eb35b20dccdcbfb36f48d8952a2ed2d3e25b70361007d953b"
+checksum = "77ca8bcaea3feb2d2ce9dbeb061ee48365312a351faa7014c417b0365fe9e459"
 dependencies = [
+ "serde",
+ "serde_json",
  "wit-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/starlark.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.4"
+zed_extension_api = "0.0.6"
 
 [build-dependencies]
 toml_edit = "0.22.9"

--- a/extension.toml
+++ b/extension.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/zaucy/zed-starlark"
 [language_servers.starpls]
 name = "Starpls"
 language = "Starlark"
+languages = ["Starlark"]
 
 [grammars.starlark]
 repository = "https://github.com/tree-sitter-grammars/tree-sitter-starlark"

--- a/languages/starlark/config.toml
+++ b/languages/starlark/config.toml
@@ -1,6 +1,6 @@
 name = "Starlark"
 grammar = "starlark"
-path_suffixes = ["star", "bzl", "bazel", "bzlmod"]
+path_suffixes = ["star", "bzl", "bazel", "bzlmod", "WORKSPACE", "BUILD"]
 line_comments = ["# "]
 autoclose_before = ";:.,=}])>"
 brackets = [


### PR DESCRIPTION
1. Updates to `zed_extension_api = "0.0.6"`:
  a. API changes
  b. Use the `make_file_executable` method to fix an issue where the downloaded LSP binary is not executable (https://github.com/zed-industries/zed/commit/8b586ef8e7cc5aaf1917819c264be4c5efd60916)
2. Mark `WORKSPACE` and `BUILD` files as recognized Starlark files for better Bazel support.