### PR TITLE
feat: Include support for buck2

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -11,6 +11,11 @@ name = "Starpls"
 language = "Starlark"
 languages = ["Starlark"]
 
+[language_servers.buck2-lsp]
+name = "Buck2 LSP"
+language = "Starlark"
+languages = ["Starlark"]
+
 [grammars.starlark]
 repository = "https://github.com/tree-sitter-grammars/tree-sitter-starlark"
 commit = "b31a616aac5d05f927f3f9dd809789db7805b632"

--- a/languages/starlark/config.toml
+++ b/languages/starlark/config.toml
@@ -1,6 +1,6 @@
 name = "Starlark"
 grammar = "starlark"
-path_suffixes = ["star", "bzl", "bazel", "bzlmod", "WORKSPACE", "BUILD"]
+path_suffixes = ["star", "bzl", "bxl", "bazel", "bzlmod", "WORKSPACE", "BUILD", "PACKAGE", "BUCK"]
 line_comments = ["# "]
 autoclose_before = ";:.,=}])>"
 brackets = [

--- a/src/starlark.rs
+++ b/src/starlark.rs
@@ -1,10 +1,10 @@
-use starpls::StarPls;
+use starpls::Starpls;
 use zed_extension_api::{self as zed, Result};
 
 mod starpls;
 
 struct StarlarkExtension {
-    starpls: Option<StarPls>,
+    starpls: Option<Starpls>,
 }
 
 impl zed::Extension for StarlarkExtension {
@@ -19,7 +19,7 @@ impl zed::Extension for StarlarkExtension {
     ) -> Result<zed::Command> {
         match language_server_id.as_ref() {
             "starpls" => {
-                let starpls = self.starpls.get_or_insert_with(|| StarPls::new());
+                let starpls = self.starpls.get_or_insert_with(|| Starpls::new());
                 Ok(zed::Command {
                     command: starpls.language_server_binary_path(language_server_id)?,
                     args: vec![],

--- a/src/starlark.rs
+++ b/src/starlark.rs
@@ -1,102 +1,43 @@
-use std::fs;
+use starpls::StarPls;
 use zed_extension_api::{self as zed, Result};
 
+mod starpls;
+
 struct StarlarkExtension {
-    cached_binary_path: Option<String>,
-}
-
-impl StarlarkExtension {
-    fn language_server_binary_path(
-        &mut self,
-        language_server_id: &zed::LanguageServerId,
-    ) -> Result<String> {
-        if let Some(path) = &self.cached_binary_path {
-            if fs::metadata(path).map_or(false, |stat| stat.is_file()) {
-                return Ok(path.clone());
-            }
-        }
-
-        zed::set_language_server_installation_status(
-            language_server_id,
-            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
-        );
-        let (platform, arch) = zed::current_platform();
-        let release = zed::latest_github_release(
-            "withered-magic/starpls",
-            zed::GithubReleaseOptions {
-                require_assets: true,
-                pre_release: false,
-            },
-        )?;
-
-        let exe_suffix = match platform {
-            zed::Os::Windows => ".exe",
-            _ => "",
-        };
-        let asset_name = format!(
-            "starpls-{os}-{arch}{exe_suffix}",
-            arch = match arch {
-                zed::Architecture::Aarch64 => "arm64",
-                zed::Architecture::X86 => "x86", // not supported
-                zed::Architecture::X8664 => "amd64",
-            },
-            os = match platform {
-                zed::Os::Mac => "darwin",
-                zed::Os::Linux => "linux",
-                zed::Os::Windows => "windows",
-            },
-        );
-
-        let asset = release
-            .assets
-            .iter()
-            .find(|asset| asset.name == asset_name)
-            .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
-
-        let version_dir = format!("starpls-{}", release.version);
-        let binary_path = format!("{version_dir}/starpls{exe_suffix}");
-
-        if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
-            zed::set_language_server_installation_status(
-                language_server_id,
-                &zed::LanguageServerInstallationStatus::Downloading,
-            );
-
-            _ = fs::create_dir(version_dir);
-
-            zed::download_file(
-                &asset.download_url,
-                &binary_path,
-                zed::DownloadedFileType::Uncompressed,
-            )
-            .map_err(|e| format!("failed to download file: {e}"))?;
-
-            zed::make_file_executable(&binary_path)
-                .map_err(|e| format!("failed to make file executable: {e}"))?;
-        }
-
-        self.cached_binary_path = Some(binary_path.clone());
-        Ok(binary_path)
-    }
+    starpls: Option<StarPls>,
 }
 
 impl zed::Extension for StarlarkExtension {
     fn new() -> Self {
-        Self {
-            cached_binary_path: None,
-        }
+        Self { starpls: None }
     }
 
     fn language_server_command(
         &mut self,
         language_server_id: &zed::LanguageServerId,
-        _worktree: &zed::Worktree,
+        worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
-        Ok(zed::Command {
-            command: self.language_server_binary_path(language_server_id)?,
-            args: vec![],
-            env: Default::default(),
-        })
+        match language_server_id.as_ref() {
+            "starpls" => {
+                let starpls = self.starpls.get_or_insert_with(|| StarPls::new());
+                Ok(zed::Command {
+                    command: starpls.language_server_binary_path(language_server_id)?,
+                    args: vec![],
+                    env: Default::default(),
+                })
+            }
+            "buck2-lsp" => {
+                let path = worktree.which("buck2").ok_or_else(|| {
+                    "buck2 must be installed. The LSP is bundled with the buck2 cli.".to_string()
+                })?;
+                Ok(zed::Command {
+                    command: path,
+                    args: vec!["lsp".to_string()],
+                    env: Default::default(),
+                })
+            }
+            language_server_id => Err(format!("unknown language server: {language_server_id}")),
+        }
     }
 }
 

--- a/src/starpls.rs
+++ b/src/starpls.rs
@@ -1,11 +1,11 @@
 use std::fs;
 use zed_extension_api::{self as zed, Result};
 
-pub struct StarPls {
+pub struct Starpls {
     cached_binary_path: Option<String>,
 }
 
-impl StarPls {
+impl Starpls {
     pub fn new() -> Self {
         Self {
             cached_binary_path: None,

--- a/src/starpls.rs
+++ b/src/starpls.rs
@@ -1,0 +1,87 @@
+use std::fs;
+use zed_extension_api::{self as zed, Result};
+
+pub struct StarPls {
+    cached_binary_path: Option<String>,
+}
+
+impl StarPls {
+    pub fn new() -> Self {
+        Self {
+            cached_binary_path: None,
+        }
+    }
+
+    pub fn language_server_binary_path(
+        &mut self,
+        language_server_id: &zed::LanguageServerId,
+    ) -> Result<String> {
+        if let Some(path) = &self.cached_binary_path {
+            if fs::metadata(path).map_or(false, |stat| stat.is_file()) {
+                return Ok(path.clone());
+            }
+        }
+
+        zed::set_language_server_installation_status(
+            language_server_id,
+            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
+        );
+        let (platform, arch) = zed::current_platform();
+        let release = zed::latest_github_release(
+            "withered-magic/starpls",
+            zed::GithubReleaseOptions {
+                require_assets: true,
+                pre_release: false,
+            },
+        )?;
+
+        let exe_suffix = match platform {
+            zed::Os::Windows => ".exe",
+            _ => "",
+        };
+        let asset_name = format!(
+            "starpls-{os}-{arch}{exe_suffix}",
+            arch = match arch {
+                zed::Architecture::Aarch64 => "arm64",
+                zed::Architecture::X86 => "x86", // not supported
+                zed::Architecture::X8664 => "amd64",
+            },
+            os = match platform {
+                zed::Os::Mac => "darwin",
+                zed::Os::Linux => "linux",
+                zed::Os::Windows => "windows",
+            },
+        );
+
+        let asset = release
+            .assets
+            .iter()
+            .find(|asset| asset.name == asset_name)
+            .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
+
+        let version_dir = format!("starpls-{}", release.version);
+        let binary_path = format!("{version_dir}/starpls{exe_suffix}");
+
+        if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
+            zed::set_language_server_installation_status(
+                language_server_id,
+                &zed::LanguageServerInstallationStatus::Downloading,
+            );
+
+            _ = fs::create_dir(version_dir);
+
+            zed::download_file(
+                &asset.download_url,
+                &binary_path,
+                zed::DownloadedFileType::Uncompressed,
+            )
+            .map_err(|e| format!("failed to download file: {e}"))?;
+
+            zed::make_file_executable(&binary_path)
+                .map_err(|e| format!("failed to make file executable: {e}"))?;
+        }
+
+        self.cached_binary_path = Some(binary_path.clone());
+        Ok(binary_path)
+    }
+}


### PR DESCRIPTION
Given both build systems leverage starlark, thought i might as well just submit a PR to this extension instead of creating a separate one specific to Buck2. Hope that's fine, [buck2](https://github.com/facebook/buck2).

Similar to the elixir situation in Zed, this'll require extra configuration to be added to the default zed settings. Something along the lines:

```json
    "Starlark": {
      "language_servers": ["starpls", "!buck2-lsp"]
    }
```

Do please include it when opening the PR to Zed, you can include it here:
https://github.com/zed-industries/zed/blob/main/assets/settings/default.json

See how elixir does it:
https://github.com/zed-industries/zed/blob/59ce3535d38946acaa7f7dcf6fcdf0aedd127432/assets/settings/default.json#L737-L739

Those who'd like to use buck2 can by changing it to:

```json
    "Starlark": {
      "language_servers": ["!starpls", "buck2-lsp"]
    }
```