### PR TITLE
Add support for https://tilt.dev files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,34 @@
 # Starlark / Bazel support for Zed
 
-* [Starpls](https://github.com/withered-magic/starpls) LSP for starlark, bazel, and buck files
+* [Starpls](https://github.com/withered-magic/starpls) LSP for starlark, bazel, and buck files.
+* [Buck2](https://buck2.build/) LSP for buck files.
 * Tree sitter syntax for [starlark](https://github.com/tree-sitter-grammars/tree-sitter-starlark) _and_ [bazelrc](https://github.com/zaucy/tree-sitter-bazelrc) files
+* [Tilt](https://tilt.dev/) LSP for Tiltfiles.
+
+## Configure the LSP
+
+By default, the extension only loads the Starpls LSP. If your project uses Buck2 or Tilt, you must manually enable the corresponding LSP in your zed settings
+
+To use buck2:
+
+```json
+{
+  "languages": {
+    "Starlark": {
+      "language_servers": ["buck2-lsp", "!starpls", "!tilt"]
+    }
+  }
+}
+```
+
+To use tilt:
+
+```json
+{
+  "languages": {
+    "Starlark": {
+      "language_servers": ["tilt", "!starpls", "!buck2-lsp"]
+    }
+  }
+}
+```

--- a/example/Tiltfile
+++ b/example/Tiltfile
@@ -1,0 +1,2 @@
+def cool_fn(a, b):
+    return a + b

--- a/extension.toml
+++ b/extension.toml
@@ -16,6 +16,11 @@ name = "Buck2 LSP"
 language = "Starlark"
 languages = ["Starlark"]
 
+[language_servers.tilt]
+name = "Tilt LSP"
+language = "Starlark"
+languages = ["Starlark"]
+
 [grammars.starlark]
 repository = "https://github.com/tree-sitter-grammars/tree-sitter-starlark"
 commit = "b31a616aac5d05f927f3f9dd809789db7805b632"

--- a/languages/starlark/config.toml
+++ b/languages/starlark/config.toml
@@ -1,6 +1,19 @@
 name = "Starlark"
 grammar = "starlark"
-path_suffixes = ["star", "bzl", "bxl", "bazel", "bzlmod", "WORKSPACE", "BUILD", "PACKAGE", "BUCK"]
+path_suffixes = [
+    "star",
+    "bzl",
+    "bxl",
+    "bazel",
+    "bzlmod",
+    "WORKSPACE",
+    "BUILD",
+    "PACKAGE",
+    "BUCK",
+    "Tiltfile",
+    ".tiltfile",
+    ".tilt",
+]
 line_comments = ["# "]
 autoclose_before = ";:.,=}])>"
 brackets = [

--- a/src/starlark.rs
+++ b/src/starlark.rs
@@ -43,6 +43,17 @@ impl zed::Extension for StarlarkExtension {
                     env: Default::default(),
                 })
             }
+            "tilt" => {
+                let path = worktree.which("tilt").ok_or_else(|| {
+                    "`tilt` must be installed. The LSP is bundled with the tilt cli.".to_string()
+                })?;
+
+                Ok(zed::Command {
+                    command: path,
+                    args: vec!["lsp".to_string(), "start".to_string()],
+                    env: Default::default(),
+                })
+            }
             language_server_id => Err(format!("unknown language server: {language_server_id}")),
         }
     }


### PR DESCRIPTION
Closes #10 

This PR adds support for https://tilt.dev files (i.e. `Tiltfile`). Tilt also uses starlark as a language.

I have also added instructions to the README to configure up the other language servers.